### PR TITLE
updated name of python-catkin_pkg

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,17 +1,17 @@
 pkgbase = ros-noetic-catkin
 	pkgdesc = ROS - Low-level build system macros and infrastructure for ROS.
 	pkgver = 0.8.10
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/catkin
 	arch = any
 	license = BSD
 	makedepends = cmake
-	makedepends = python-catkin-pkg
+	makedepends = python-catkin_pkg
 	makedepends = python-empy
 	makedepends = python
 	depends = python-nose
 	depends = gtest
-	depends = python-catkin-pkg
+	depends = python-catkin_pkg
 	depends = python-empy
 	depends = gmock
 	depends = python
@@ -20,4 +20,3 @@ pkgbase = ros-noetic-catkin
 	sha256sums = 363857f037d8f300a5889d00dc8248673f363d587d639c11e23f1f0fd3c22b92
 
 pkgname = ros-noetic-catkin
-

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ url='https://wiki.ros.org/catkin'
 pkgname='ros-noetic-catkin'
 pkgver='0.8.10'
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(
@@ -13,7 +13,7 @@ ros_makedepends=(
 makedepends=(
     cmake
     ${ros_makedepends[@]}
-    python-catkin-pkg
+    python-catkin_pkg
     python-empy
     python
 )
@@ -25,7 +25,7 @@ depends=(
     ${ros_depends[@]}
     python-nose
     gtest
-    python-catkin-pkg
+    python-catkin_pkg
     python-empy
     gmock
     python


### PR DESCRIPTION
I couldn't build this due to a failure to resolve the dependency `python-catkin-pkg` which I believe should be `python-catkin_pkg`.